### PR TITLE
The sessionID is set to message.user, to have a separate session for each user.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "apiai": "^4.0.3",
     "debug": "^3.1.0",
+    "hasha": "^3.0.0",
     "node-uuid": "^1.4.8"
   },
   "devDependencies": {

--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -11,6 +11,10 @@ module.exports = function(config) {
         config.minimum_confidence = 0.5;
     }
 
+    if (!config.sessionIdProps) {
+        config.sessionIdProps = ['user', 'channel'];
+    }
+
     var ignoreTypePatterns = makeArrayOfRegex(config.ignoreType || []);
 
     var app = apiai(config.token);
@@ -37,9 +41,16 @@ module.exports = function(config) {
             app.language = 'en';
         }
 
+        var requestSessionId = "";
+        for (var i = 0; i < config.sessionIdProps.length; i++) {
+            requestSessionId += message[config.sessionIdProps[i]];
+        }
+
+        console.log("SessiodId is: " + requestSessionId);
+
         debug('Sending message to dialogflow. user=%s, language=%s, text=%s', message.user, app.language, message.text);
         request = app.textRequest(message.text, {
-            sessionId: message.user,
+            sessionId: requestSessionId,
         });
 
         request.on('response', function(response) {

--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -1,6 +1,5 @@
 var debug = require('debug')('dialogflow-middleware');
 var apiai = require('apiai');
-var uuid = require('node-uuid');
 var makeArrayOfRegex = require('./util').makeArrayOfRegex;
 
 module.exports = function(config) {
@@ -17,7 +16,6 @@ module.exports = function(config) {
     var app = apiai(config.token);
 
     var middleware = {};
-    var sessionId = uuid.v1();
 
     middleware.receive = function(bot, message, next) {
         if (!message.text || message.is_echo || message.type === 'self_message') {

--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -56,7 +56,7 @@ module.exports = function(config) {
             }
         }
         requestSessionId = hasha(requestSessionId, {
-            algorithm: 'md5'
+            algorithm: 'md5',
         });
 
         debug('Sending message to dialogflow. sessionId=%s, language=%s, text=%s',

--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
     if (!config.sessionIdProps) {
         config.sessionIdProps = ['user', 'channel'];
     } else if (config.sessionIdProps.length == 0) {
-        throw new Error('sessionIdProps field must contain at least an element'); 
+        throw new Error('sessionIdProps field must contain at least an element');
     }
 
     var ignoreTypePatterns = makeArrayOfRegex(config.ignoreType || []);
@@ -49,14 +49,18 @@ module.exports = function(config) {
             if (message[config.sessionIdProps[i]]) {
                 requestSessionId += message[config.sessionIdProps[i]];
             } else {
-                debug('skipping call to Dialogflow since field %s doesn\'t exist in message object', config.sessionIdProps[i]);
+                debug('skipping call to Dialogflow since field "%s" doesn\'t exist in message object',
+                    config.sessionIdProps[i]);
                 next();
                 return;
-            }     
+            }
         }
-        requestSessionId = hasha(requestSessionId, {algorithm: 'md5'});
+        requestSessionId = hasha(requestSessionId, {
+            algorithm: 'md5'
+        });
 
-        debug('Sending message to dialogflow. sessionId=%s, language=%s, text=%s', requestSessionId, app.language, message.text);
+        debug('Sending message to dialogflow. sessionId=%s, language=%s, text=%s',
+            requestSessionId, app.language, message.text);
         request = app.textRequest(message.text, {
             sessionId: requestSessionId,
         });

--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -39,9 +39,9 @@ module.exports = function(config) {
             app.language = 'en';
         }
 
-        debug('Sending message to dialogflow. language=%s, text=%s', app.language, message.text);
+        debug('Sending message to dialogflow. user=%s, language=%s, text=%s', message.user, app.language, message.text);
         request = app.textRequest(message.text, {
-            sessionId: sessionId,
+            sessionId: message.user,
         });
 
         request.on('response', function(response) {

--- a/test/test.action.js
+++ b/test/test.action.js
@@ -20,6 +20,8 @@ describe('action()', function() {
     var message = {
         type: 'direct_message',
         text: 'pick an apple',
+        user: 'test_user',
+        channel: 'test_channel',
     };
 
     // response from DialogFlow api call to /query endpoint

--- a/test/test.receive_language.js
+++ b/test/test.receive_language.js
@@ -21,18 +21,24 @@ describe('receive() text language support', function() {
     const defaultMessage = {
         type: 'direct_message',
         text: 'hi',
+        user: 'test_user',
+        channel: 'test_channel',
     };
 
     const englishMessage = {
         type: 'direct_message',
         text: 'hi',
         lang: 'en',
+        user: 'test_user',
+        channel: 'test_channel',
     };
 
     const frenchMessage = {
         type: 'direct_message',
         text: 'bonjour',
         lang: 'fr',
+        user: 'test_user',
+        channel: 'test_channel',
     };
 
     // tests


### PR DESCRIPTION
I changed the unique `sessionId` with the user ID (`message.user`), during a request to Dialogflow: in this way we have a session for each user.
In the original implementation if two (or more) users talk to the bot at the same time, the conversation (with all the Dialogflow contexts) will be mixed, because the session ID is the same for every user.

A more robust way could be to use as ID the concatenation of `message.user` and `message.channel`, or simply `message.channel` in order to allow users to share the session (with the Dialogflow contexts) in the same chat.