### PR TITLE
Fix projectId not detected when passed in config

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -72,11 +72,12 @@ class DialogFlowAPI_V2 {
     } else {
       try {
         const keyFile = require(config.keyFilename);
-        this.projectId = keyFile.project_id;
+        opts.projectId = keyFile.project_id;
       } catch (err) {
         throw new Error('projectId must be provided or available in the keyFile.');
       }
     }
+    this.projectId = opts.projectId;
     if (config.credentials) {
       opts.credentials = config.credentials;
     }


### PR DESCRIPTION
This pull request fixes a bug where the option `projectId` isn't stored when being passed as a variable in the config object of DialogFlowAPI_V2.

Fixes #13 