### PR TITLE
Using message.token as session ID

### DIFF
--- a/src/botkit-middleware-dialogflow.js
+++ b/src/botkit-middleware-dialogflow.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
       }
     }
 
-    const sessionId = util.generateSessionId(config, message);
+    const sessionId = message.token.substring(0,message.token.length-1);
     const lang = message.lang || config.lang;
 
     debug(


### PR DESCRIPTION
To have persistance in dialogflow sessions I changed to use ID from dialogflow (token)